### PR TITLE
Streamlime footer control

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/TaskDialogFooter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TaskDialogFooter.cs
@@ -14,9 +14,7 @@ namespace System.Windows.Forms
     public sealed class TaskDialogFooter : TaskDialogControl
     {
         private string? _text;
-
         private TaskDialogIcon? _icon;
-
         private bool _boundIconIsFromHandle;
 
         /// <summary>
@@ -36,6 +34,9 @@ namespace System.Windows.Forms
         {
             _text = text;
         }
+
+        public static implicit operator TaskDialogFooter(string footerText)
+          => new TaskDialogFooter(footerText);
 
         /// <summary>
         ///   Gets or sets the text to be displayed in the dialog's footer area.


### PR DESCRIPTION
Add an implicit operator to reduce boilerplate code:
```
var footer = new TaskDialogFooter("<a href=\"https://getdot.net/\">Download .NET!</a>");
taskDialog.Page.Footer = footer;
```

to

```
taskDialog.Page.Footer = "<a href=\"https://getdot.net/\">Download .NET!</a>";
```
