### PR TITLE
Tweak api

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/TaskDialogButton.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TaskDialogButton.cs
@@ -26,10 +26,10 @@ namespace System.Windows.Forms
         ///   (except for the <see cref="TaskDialogResult.Help"/> button, which instead
         ///   will raise the <see cref="TaskDialogPage.HelpRequest"/> event afterwards).
         ///   To prevent the dialog from closing when this button is clicked, set the
-        ///   <see cref="ShouldCloseDialog"/> property to <see langword="false"/>.
+        ///   <see cref="AllowCloseDialog"/> property to <see langword="false"/>.
         /// </para>
         /// <para>
-        ///   When <see cref="ShouldCloseDialog"/> is set to <see langword="true"/>,
+        ///   When <see cref="AllowCloseDialog"/> is set to <see langword="true"/>,
         ///   the <see cref="TaskDialog.Closing"/> event will occur afterwards,
         ///   which also allows you to prevent the dialog from closing.
         /// </para>
@@ -60,7 +60,7 @@ namespace System.Windows.Forms
         ///   sets the clicked button as result value.
         /// </para>
         /// </remarks>
-        public bool ShouldCloseDialog { get; set; } = true;
+        public bool AllowCloseDialog { get; set; } = true;
 
         /// <summary>
         ///   Gets or sets a value indicating whether the button can respond to user interaction.
@@ -185,7 +185,7 @@ namespace System.Windows.Forms
         {
             OnClick(EventArgs.Empty);
 
-            return ShouldCloseDialog;
+            return AllowCloseDialog;
         }
 
         private protected override void ApplyInitializationCore()

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TaskDialogCustomButton.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TaskDialogCustomButton.cs
@@ -39,11 +39,20 @@ namespace System.Windows.Forms
         /// <param name="descriptionText">An additional description text that will be displayed in
         /// a separate line when the <see cref="TaskDialogCustomButton"/>s of the task dialog are
         /// shown as command links (see <see cref="DescriptionText"/>).</param>
-        public TaskDialogCustomButton(string? text, string? descriptionText = null)
+        /// <param name="defaultButton">A value that indicates whether this button is the default button
+        /// in the task dialog.
+        /// </param>
+        /// <param name="allowCloseDialog">A value that indicates whether the task dialog should close
+        ///   when this button is clicked.
+        /// </param>
+        public TaskDialogCustomButton(string? text, string? descriptionText = null, bool enabled = true, bool defaultButton = false, bool allowCloseDialog = true)
             : this()
         {
             _text = text;
             _descriptionText = descriptionText;
+            Enabled = enabled;
+            DefaultButton = defaultButton;
+            AllowCloseDialog = allowCloseDialog;
         }
 
         /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TaskDialogCustomButtonCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TaskDialogCustomButtonCollection.cs
@@ -35,16 +35,19 @@ namespace System.Windows.Forms
         /// </summary>
         /// <param name="text">The text of the custom button.</param>
         /// <param name="descriptionText">The description text of the custom button.</param>
+        /// <param name="enabled">A value indicating whether the button can respond to user interaction.</param>
+        /// <param name="defaultButton">A value that indicates whether this button is the default button
+        ///   in the task dialog.
+        /// </param>
+        /// <param name="allowCloseDialog">A value that indicates whether the task dialog should close
+        ///   when this button is clicked.
+        /// </param>
         /// <returns>The created <see cref="TaskDialogCustomButton"/>.</returns>
-        public TaskDialogCustomButton Add(string? text, string? descriptionText = null)
+        public TaskDialogCustomButton Add(string? text, string? descriptionText = null, bool enabled = true, bool defaultButton = false, bool allowCloseDialog = true)
         {
-            var button = new TaskDialogCustomButton()
-            {
-                Text = text,
-                DescriptionText = descriptionText
-            };
-
+            var button = new TaskDialogCustomButton(text, descriptionText, enabled, defaultButton, allowCloseDialog);
             Add(button);
+
             return button;
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TaskDialogPage.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TaskDialogPage.cs
@@ -109,12 +109,12 @@ namespace System.Windows.Forms
             _customButtons = new TaskDialogCustomButtonCollection();
             _standardButtons = new TaskDialogStandardButtonCollection();
             _radioButtons = new TaskDialogRadioButtonCollection();
-            
+
             // Create empty (hidden) controls.
             _checkBox = new TaskDialogCheckBox();
             _expander = new TaskDialogExpander();
             _footer = new TaskDialogFooter();
-            _progressBar = new TaskDialogProgressBar(TaskDialogProgressBarState.None);            
+            _progressBar = new TaskDialogProgressBar(TaskDialogProgressBarState.None);
         }
 
         /// <summary>
@@ -523,7 +523,7 @@ namespace System.Windows.Forms
         ///   automatically implied.
         /// </para>
         /// </remarks>
-        public bool CanBeMinimized
+        public bool AllowMinimize
         {
             get => GetFlag(ComCtl32.TDF.CAN_BE_MINIMIZED);
             set => SetFlag(ComCtl32.TDF.CAN_BE_MINIMIZED, value);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TaskDialogStandardButton.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TaskDialogStandardButton.cs
@@ -40,12 +40,20 @@ namespace System.Windows.Forms
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="TaskDialogStandardButton"/> class
-        /// using the specified result.
+        ///  Initializes a new instance of the <see cref="TaskDialogStandardButton"/> class
+        ///  using the specified result.
         /// </summary>
-        /// <param name="result">The <see cref="TaskDialogResult"/> that is represent by this
-        /// <see cref="TaskDialogStandardButton"/>.</param>
-        public TaskDialogStandardButton(TaskDialogResult result)
+        /// <param name="result">The <see cref="TaskDialogResult"/> that is represent by this 
+        ///   <see cref="TaskDialogStandardButton"/>.
+        /// </param>
+        /// <param name="enabled">A value indicating whether the button can respond to user interaction.</param>
+        /// <param name="defaultButton">A value that indicates whether this button is the default button
+        ///   in the task dialog.
+        /// </param>
+        /// <param name="allowCloseDialog">A value that indicates whether the task dialog should close
+        ///   when this button is clicked.
+        /// </param>
+        public TaskDialogStandardButton(TaskDialogResult result, bool enabled = true, bool defaultButton = false, bool allowCloseDialog = true)
         {
             if (!IsValidStandardButtonResult(result))
             {
@@ -53,6 +61,9 @@ namespace System.Windows.Forms
             }
 
             _result = result;
+            Enabled = enabled;
+            DefaultButton = defaultButton;
+            AllowCloseDialog = allowCloseDialog;
         }
 
         /// <summary>
@@ -136,7 +147,7 @@ namespace System.Windows.Forms
             _ => default
         };
 
-        private static bool IsValidStandardButtonResult(TaskDialogResult result) => 
+        private static bool IsValidStandardButtonResult(TaskDialogResult result) =>
             GetButtonFlagForResult(result) != default;
 
         /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TaskDialogStandardButtonCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TaskDialogStandardButtonCollection.cs
@@ -97,17 +97,24 @@ namespace System.Windows.Forms
         ///   Creates and adds a <see cref="TaskDialogStandardButton"/> to the collection.
         /// </summary>
         /// <param name="result">The <see cref="TaskDialogResult"/> that is represented by the
-        /// <see cref="TaskDialogStandardButton"/>.</param>
+        ///   <see cref="TaskDialogStandardButton"/>.</param>
+        /// <param name="enabled">A value indicating whether the button can respond to user interaction.</param>
+        /// <param name="defaultButton">A value that indicates whether this button is the default button
+        ///   in the task dialog.
+        /// </param>
+        /// <param name="allowCloseDialog">A value that indicates whether the task dialog should close
+        ///   when this button is clicked.
+        /// </param>
         /// <returns>The created <see cref="TaskDialogStandardButton"/>.</returns>
-        public TaskDialogStandardButton Add(TaskDialogResult result)
+        public TaskDialogStandardButton Add(TaskDialogResult result, bool enabled = true, bool defaultButton = false, bool allowCloseDialog = true)
         {
-            var button = new TaskDialogStandardButton(result);
+            var button = new TaskDialogStandardButton(result, enabled, defaultButton, allowCloseDialog);
             Add(button);
 
             return button;
         }
 
-        internal void HandleKeyChange(TaskDialogStandardButton button, TaskDialogResult newKey) => 
+        internal void HandleKeyChange(TaskDialogStandardButton button, TaskDialogResult newKey) =>
             ChangeItemKey(button, newKey);
 
         /// <inheritdoc/>


### PR DESCRIPTION
* Rename `CanBeMinimized` -> `AllowMinimize`
* Rename `ShouldCloseDialog` -> `AllowCloseDialog`
* Add overloads for `defaultButton`, `enabled`, `allowCloseDialog`
	This way we can reduce a boilerplate code:
	```
	TaskDialogStandardButton button1 = page.StandardButtons.Add(TaskDialogResult.No);
	button1.Enabled = false;
	button1.AllowCloseDialog = false;
	button1.DefaultButton = true;

	TaskDialogCustomButton button2 = page.CustomButtons.Add("&Save", "Save the document");
	button2.Enabled = false;
	button2.AllowCloseDialog = false;
	button2.DefaultButton = true;
	```

	to

	```
	TaskDialogStandardButton button1 = page.StandardButtons.Add(TaskDialogResult.No, enabled: false, defaultButton: true, allowCloseDialog: false);
	TaskDialogStandardButton button2 = page.CustomButtons.Add("&Save", "Save the document", enabled: false, defaultButton: true, allowCloseDialog: false);
	```
