### PR TITLE
Shift the deafult button assignment to the dialog

### DIFF
--- a/src/System.Windows.Forms/src/Resources/SR.resx
+++ b/src/System.Windows.Forms/src/Resources/SR.resx
@@ -6725,8 +6725,8 @@ Stack trace where the illegal operation occurred was:
   <data name="TaskDialogVisualStylesNotEnabled" xml:space="preserve">
     <value>Visual styles are not enabled. Please call {0} before showing the task dialog.</value>
   </data>
-  <data name="TaskDialogOnlySingleButtonCanBeDefault" xml:space="preserve">
-    <value>Only a single button can be set as default button.</value>
+  <data name="TaskDialogDefaultButtonMustExistInCollection" xml:space="preserve">
+    <value>The default button must exist in the buttons collection.</value>
   </data>
   <data name="TaskDialogOnlySingleRadioButtonCanBeChecked" xml:space="preserve">
     <value>Only a single radio button can be set as checked.</value>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.cs.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.cs.xlf
@@ -9231,6 +9231,11 @@ Trasování zásobníku, kde došlo k neplatné operaci:
         <target state="new">The control has not been created.</target>
         <note />
       </trans-unit>
+      <trans-unit id="TaskDialogDefaultButtonMustExistInCollection">
+        <source>The default button must exist in the buttons collection.</source>
+        <target state="new">The default button must exist in the buttons collection.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TaskDialogInstanceAlreadyShown">
         <source>This {0} instance is already being shown.</source>
         <target state="new">This {0} instance is already being shown.</target>
@@ -9239,11 +9244,6 @@ Trasování zásobníku, kde došlo k neplatné operaci:
       <trans-unit id="TaskDialogNavigationNotCompleted">
         <source>Navigation of the task dialog did not complete yet. Please wait for the {0} event to occur.</source>
         <target state="new">Navigation of the task dialog did not complete yet. Please wait for the {0} event to occur.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TaskDialogOnlySingleButtonCanBeDefault">
-        <source>Only a single button can be set as default button.</source>
-        <target state="new">Only a single button can be set as default button.</target>
         <note />
       </trans-unit>
       <trans-unit id="TaskDialogOnlySingleRadioButtonCanBeChecked">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.de.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.de.xlf
@@ -9231,6 +9231,11 @@ Stapelüberwachung, in der der unzulässige Vorgang auftrat:
         <target state="new">The control has not been created.</target>
         <note />
       </trans-unit>
+      <trans-unit id="TaskDialogDefaultButtonMustExistInCollection">
+        <source>The default button must exist in the buttons collection.</source>
+        <target state="new">The default button must exist in the buttons collection.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TaskDialogInstanceAlreadyShown">
         <source>This {0} instance is already being shown.</source>
         <target state="new">This {0} instance is already being shown.</target>
@@ -9239,11 +9244,6 @@ Stapelüberwachung, in der der unzulässige Vorgang auftrat:
       <trans-unit id="TaskDialogNavigationNotCompleted">
         <source>Navigation of the task dialog did not complete yet. Please wait for the {0} event to occur.</source>
         <target state="new">Navigation of the task dialog did not complete yet. Please wait for the {0} event to occur.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TaskDialogOnlySingleButtonCanBeDefault">
-        <source>Only a single button can be set as default button.</source>
-        <target state="new">Only a single button can be set as default button.</target>
         <note />
       </trans-unit>
       <trans-unit id="TaskDialogOnlySingleRadioButtonCanBeChecked">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.es.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.es.xlf
@@ -9231,6 +9231,11 @@ El seguimiento de la pila donde tuvo lugar la operación no válida fue:
         <target state="new">The control has not been created.</target>
         <note />
       </trans-unit>
+      <trans-unit id="TaskDialogDefaultButtonMustExistInCollection">
+        <source>The default button must exist in the buttons collection.</source>
+        <target state="new">The default button must exist in the buttons collection.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TaskDialogInstanceAlreadyShown">
         <source>This {0} instance is already being shown.</source>
         <target state="new">This {0} instance is already being shown.</target>
@@ -9239,11 +9244,6 @@ El seguimiento de la pila donde tuvo lugar la operación no válida fue:
       <trans-unit id="TaskDialogNavigationNotCompleted">
         <source>Navigation of the task dialog did not complete yet. Please wait for the {0} event to occur.</source>
         <target state="new">Navigation of the task dialog did not complete yet. Please wait for the {0} event to occur.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TaskDialogOnlySingleButtonCanBeDefault">
-        <source>Only a single button can be set as default button.</source>
-        <target state="new">Only a single button can be set as default button.</target>
         <note />
       </trans-unit>
       <trans-unit id="TaskDialogOnlySingleRadioButtonCanBeChecked">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.fr.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.fr.xlf
@@ -9231,6 +9231,11 @@ Cette opération non conforme s'est produite sur la trace de la pile :
         <target state="new">The control has not been created.</target>
         <note />
       </trans-unit>
+      <trans-unit id="TaskDialogDefaultButtonMustExistInCollection">
+        <source>The default button must exist in the buttons collection.</source>
+        <target state="new">The default button must exist in the buttons collection.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TaskDialogInstanceAlreadyShown">
         <source>This {0} instance is already being shown.</source>
         <target state="new">This {0} instance is already being shown.</target>
@@ -9239,11 +9244,6 @@ Cette opération non conforme s'est produite sur la trace de la pile :
       <trans-unit id="TaskDialogNavigationNotCompleted">
         <source>Navigation of the task dialog did not complete yet. Please wait for the {0} event to occur.</source>
         <target state="new">Navigation of the task dialog did not complete yet. Please wait for the {0} event to occur.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TaskDialogOnlySingleButtonCanBeDefault">
-        <source>Only a single button can be set as default button.</source>
-        <target state="new">Only a single button can be set as default button.</target>
         <note />
       </trans-unit>
       <trans-unit id="TaskDialogOnlySingleRadioButtonCanBeChecked">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.it.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.it.xlf
@@ -9231,6 +9231,11 @@ Traccia dello stack da cui si è verificata l'operazione non valida:
         <target state="new">The control has not been created.</target>
         <note />
       </trans-unit>
+      <trans-unit id="TaskDialogDefaultButtonMustExistInCollection">
+        <source>The default button must exist in the buttons collection.</source>
+        <target state="new">The default button must exist in the buttons collection.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TaskDialogInstanceAlreadyShown">
         <source>This {0} instance is already being shown.</source>
         <target state="new">This {0} instance is already being shown.</target>
@@ -9239,11 +9244,6 @@ Traccia dello stack da cui si è verificata l'operazione non valida:
       <trans-unit id="TaskDialogNavigationNotCompleted">
         <source>Navigation of the task dialog did not complete yet. Please wait for the {0} event to occur.</source>
         <target state="new">Navigation of the task dialog did not complete yet. Please wait for the {0} event to occur.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TaskDialogOnlySingleButtonCanBeDefault">
-        <source>Only a single button can be set as default button.</source>
-        <target state="new">Only a single button can be set as default button.</target>
         <note />
       </trans-unit>
       <trans-unit id="TaskDialogOnlySingleRadioButtonCanBeChecked">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ja.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ja.xlf
@@ -9231,6 +9231,11 @@ Stack trace where the illegal operation occurred was:
         <target state="new">The control has not been created.</target>
         <note />
       </trans-unit>
+      <trans-unit id="TaskDialogDefaultButtonMustExistInCollection">
+        <source>The default button must exist in the buttons collection.</source>
+        <target state="new">The default button must exist in the buttons collection.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TaskDialogInstanceAlreadyShown">
         <source>This {0} instance is already being shown.</source>
         <target state="new">This {0} instance is already being shown.</target>
@@ -9239,11 +9244,6 @@ Stack trace where the illegal operation occurred was:
       <trans-unit id="TaskDialogNavigationNotCompleted">
         <source>Navigation of the task dialog did not complete yet. Please wait for the {0} event to occur.</source>
         <target state="new">Navigation of the task dialog did not complete yet. Please wait for the {0} event to occur.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TaskDialogOnlySingleButtonCanBeDefault">
-        <source>Only a single button can be set as default button.</source>
-        <target state="new">Only a single button can be set as default button.</target>
         <note />
       </trans-unit>
       <trans-unit id="TaskDialogOnlySingleRadioButtonCanBeChecked">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ko.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ko.xlf
@@ -9231,6 +9231,11 @@ Stack trace where the illegal operation occurred was:
         <target state="new">The control has not been created.</target>
         <note />
       </trans-unit>
+      <trans-unit id="TaskDialogDefaultButtonMustExistInCollection">
+        <source>The default button must exist in the buttons collection.</source>
+        <target state="new">The default button must exist in the buttons collection.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TaskDialogInstanceAlreadyShown">
         <source>This {0} instance is already being shown.</source>
         <target state="new">This {0} instance is already being shown.</target>
@@ -9239,11 +9244,6 @@ Stack trace where the illegal operation occurred was:
       <trans-unit id="TaskDialogNavigationNotCompleted">
         <source>Navigation of the task dialog did not complete yet. Please wait for the {0} event to occur.</source>
         <target state="new">Navigation of the task dialog did not complete yet. Please wait for the {0} event to occur.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TaskDialogOnlySingleButtonCanBeDefault">
-        <source>Only a single button can be set as default button.</source>
-        <target state="new">Only a single button can be set as default button.</target>
         <note />
       </trans-unit>
       <trans-unit id="TaskDialogOnlySingleRadioButtonCanBeChecked">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.pl.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.pl.xlf
@@ -9231,6 +9231,11 @@ Stos śledzenia, w którym wystąpiła zabroniona operacja:
         <target state="new">The control has not been created.</target>
         <note />
       </trans-unit>
+      <trans-unit id="TaskDialogDefaultButtonMustExistInCollection">
+        <source>The default button must exist in the buttons collection.</source>
+        <target state="new">The default button must exist in the buttons collection.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TaskDialogInstanceAlreadyShown">
         <source>This {0} instance is already being shown.</source>
         <target state="new">This {0} instance is already being shown.</target>
@@ -9239,11 +9244,6 @@ Stos śledzenia, w którym wystąpiła zabroniona operacja:
       <trans-unit id="TaskDialogNavigationNotCompleted">
         <source>Navigation of the task dialog did not complete yet. Please wait for the {0} event to occur.</source>
         <target state="new">Navigation of the task dialog did not complete yet. Please wait for the {0} event to occur.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TaskDialogOnlySingleButtonCanBeDefault">
-        <source>Only a single button can be set as default button.</source>
-        <target state="new">Only a single button can be set as default button.</target>
         <note />
       </trans-unit>
       <trans-unit id="TaskDialogOnlySingleRadioButtonCanBeChecked">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.pt-BR.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.pt-BR.xlf
@@ -9231,6 +9231,11 @@ Rastreamento de pilha em que a operação ilegal ocorreu:
         <target state="new">The control has not been created.</target>
         <note />
       </trans-unit>
+      <trans-unit id="TaskDialogDefaultButtonMustExistInCollection">
+        <source>The default button must exist in the buttons collection.</source>
+        <target state="new">The default button must exist in the buttons collection.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TaskDialogInstanceAlreadyShown">
         <source>This {0} instance is already being shown.</source>
         <target state="new">This {0} instance is already being shown.</target>
@@ -9239,11 +9244,6 @@ Rastreamento de pilha em que a operação ilegal ocorreu:
       <trans-unit id="TaskDialogNavigationNotCompleted">
         <source>Navigation of the task dialog did not complete yet. Please wait for the {0} event to occur.</source>
         <target state="new">Navigation of the task dialog did not complete yet. Please wait for the {0} event to occur.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TaskDialogOnlySingleButtonCanBeDefault">
-        <source>Only a single button can be set as default button.</source>
-        <target state="new">Only a single button can be set as default button.</target>
         <note />
       </trans-unit>
       <trans-unit id="TaskDialogOnlySingleRadioButtonCanBeChecked">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ru.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ru.xlf
@@ -9232,6 +9232,11 @@ Stack trace where the illegal operation occurred was:
         <target state="new">The control has not been created.</target>
         <note />
       </trans-unit>
+      <trans-unit id="TaskDialogDefaultButtonMustExistInCollection">
+        <source>The default button must exist in the buttons collection.</source>
+        <target state="new">The default button must exist in the buttons collection.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TaskDialogInstanceAlreadyShown">
         <source>This {0} instance is already being shown.</source>
         <target state="new">This {0} instance is already being shown.</target>
@@ -9240,11 +9245,6 @@ Stack trace where the illegal operation occurred was:
       <trans-unit id="TaskDialogNavigationNotCompleted">
         <source>Navigation of the task dialog did not complete yet. Please wait for the {0} event to occur.</source>
         <target state="new">Navigation of the task dialog did not complete yet. Please wait for the {0} event to occur.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TaskDialogOnlySingleButtonCanBeDefault">
-        <source>Only a single button can be set as default button.</source>
-        <target state="new">Only a single button can be set as default button.</target>
         <note />
       </trans-unit>
       <trans-unit id="TaskDialogOnlySingleRadioButtonCanBeChecked">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.tr.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.tr.xlf
@@ -9231,6 +9231,11 @@ Geçersiz işlemin gerçekleştiği yığın izi:
         <target state="new">The control has not been created.</target>
         <note />
       </trans-unit>
+      <trans-unit id="TaskDialogDefaultButtonMustExistInCollection">
+        <source>The default button must exist in the buttons collection.</source>
+        <target state="new">The default button must exist in the buttons collection.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TaskDialogInstanceAlreadyShown">
         <source>This {0} instance is already being shown.</source>
         <target state="new">This {0} instance is already being shown.</target>
@@ -9239,11 +9244,6 @@ Geçersiz işlemin gerçekleştiği yığın izi:
       <trans-unit id="TaskDialogNavigationNotCompleted">
         <source>Navigation of the task dialog did not complete yet. Please wait for the {0} event to occur.</source>
         <target state="new">Navigation of the task dialog did not complete yet. Please wait for the {0} event to occur.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TaskDialogOnlySingleButtonCanBeDefault">
-        <source>Only a single button can be set as default button.</source>
-        <target state="new">Only a single button can be set as default button.</target>
         <note />
       </trans-unit>
       <trans-unit id="TaskDialogOnlySingleRadioButtonCanBeChecked">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hans.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hans.xlf
@@ -9231,6 +9231,11 @@ Stack trace where the illegal operation occurred was:
         <target state="new">The control has not been created.</target>
         <note />
       </trans-unit>
+      <trans-unit id="TaskDialogDefaultButtonMustExistInCollection">
+        <source>The default button must exist in the buttons collection.</source>
+        <target state="new">The default button must exist in the buttons collection.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TaskDialogInstanceAlreadyShown">
         <source>This {0} instance is already being shown.</source>
         <target state="new">This {0} instance is already being shown.</target>
@@ -9239,11 +9244,6 @@ Stack trace where the illegal operation occurred was:
       <trans-unit id="TaskDialogNavigationNotCompleted">
         <source>Navigation of the task dialog did not complete yet. Please wait for the {0} event to occur.</source>
         <target state="new">Navigation of the task dialog did not complete yet. Please wait for the {0} event to occur.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TaskDialogOnlySingleButtonCanBeDefault">
-        <source>Only a single button can be set as default button.</source>
-        <target state="new">Only a single button can be set as default button.</target>
         <note />
       </trans-unit>
       <trans-unit id="TaskDialogOnlySingleRadioButtonCanBeChecked">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hant.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hant.xlf
@@ -9231,6 +9231,11 @@ Stack trace where the illegal operation occurred was:
         <target state="new">The control has not been created.</target>
         <note />
       </trans-unit>
+      <trans-unit id="TaskDialogDefaultButtonMustExistInCollection">
+        <source>The default button must exist in the buttons collection.</source>
+        <target state="new">The default button must exist in the buttons collection.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TaskDialogInstanceAlreadyShown">
         <source>This {0} instance is already being shown.</source>
         <target state="new">This {0} instance is already being shown.</target>
@@ -9239,11 +9244,6 @@ Stack trace where the illegal operation occurred was:
       <trans-unit id="TaskDialogNavigationNotCompleted">
         <source>Navigation of the task dialog did not complete yet. Please wait for the {0} event to occur.</source>
         <target state="new">Navigation of the task dialog did not complete yet. Please wait for the {0} event to occur.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TaskDialogOnlySingleButtonCanBeDefault">
-        <source>Only a single button can be set as default button.</source>
-        <target state="new">Only a single button can be set as default button.</target>
         <note />
       </trans-unit>
       <trans-unit id="TaskDialogOnlySingleRadioButtonCanBeChecked">

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TaskDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TaskDialog.cs
@@ -518,13 +518,15 @@ namespace System.Windows.Forms
             string? mainInstruction = null,
             string? caption = null,
             IEnumerable<TaskDialogButton>? buttons = null,
-            TaskDialogIcon? icon = null) => ShowDialog(
+            TaskDialogIcon? icon = null,
+            TaskDialogButton? defaultButton = null) => ShowDialog(
                 IntPtr.Zero,
                 text,
                 mainInstruction,
                 caption,
                 buttons,
-                icon);
+                icon,
+                defaultButton);
 
         /// <summary>
         ///   Displays a task dialog in front of the specified window and with the specified
@@ -547,13 +549,15 @@ namespace System.Windows.Forms
             string? mainInstruction = null,
             string? caption = null,
             IEnumerable<TaskDialogButton>? buttons = null,
-            TaskDialogIcon? icon = null) => ShowDialog(
+            TaskDialogIcon? icon = null,
+            TaskDialogButton? defaultButton = null) => ShowDialog(
                 owner?.Handle ?? throw new ArgumentNullException(nameof(owner)),
                 text,
                 mainInstruction,
                 caption,
                 buttons,
-                icon);
+                icon,
+                defaultButton);
 
         /// <summary>
         ///   Displays a task dialog in front of the specified window and with the specified
@@ -579,7 +583,8 @@ namespace System.Windows.Forms
             string? mainInstruction = null,
             string? caption = null,
             IEnumerable<TaskDialogButton>? buttons = null,
-            TaskDialogIcon? icon = null)
+            TaskDialogIcon? icon = null,
+            TaskDialogButton? defaultButton = null)
         {
             var page = new TaskDialogPage()
             {
@@ -593,6 +598,8 @@ namespace System.Windows.Forms
             {
                 page.Buttons.Add(button);
             }
+
+            page.DefaultButton = defaultButton;
 
             var dialog = new TaskDialog(page);
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TaskDialogButton.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TaskDialogButton.cs
@@ -17,7 +17,6 @@ namespace System.Windows.Forms
     public class TaskDialogButton : TaskDialogControl
     {
         private bool _enabled = true;
-        private bool _defaultButton;
         private bool _elevationRequired;
         private bool _visible = true;
 
@@ -66,21 +65,17 @@ namespace System.Windows.Forms
         ///   using the given text and, optionally, a description text.
         /// </summary>
         /// <param name="text">The text of the control.</param>
-        /// <param name="defaultButton">A value that indicates whether this button is the default button
-        /// in the task dialog.
-        /// </param>
         /// <param name="allowCloseDialog">A value that indicates whether the task dialog should close
         ///   when this button is clicked.
         /// </param>
         // TODO
 #pragma warning disable RS0022 // Constructor make noninheritable base class inheritable
-        public TaskDialogButton(string? text, bool enabled = true, bool defaultButton = false, bool allowCloseDialog = true)
+        public TaskDialogButton(string? text, bool enabled = true, bool allowCloseDialog = true)
 #pragma warning restore RS0022 // Constructor make noninheritable base class inheritable
             : this()
         {
             _text = text;
             Enabled = enabled;
-            DefaultButton = defaultButton;
             AllowCloseDialog = allowCloseDialog;
         }
 
@@ -240,43 +235,6 @@ namespace System.Windows.Forms
                 }
 
                 _elevationRequired = value;
-            }
-        }
-
-        /// <summary>
-        ///   Gets or sets a value that indicates whether this button is the default button
-        ///   in the task dialog.
-        /// </summary>
-        /// <value>
-        ///   <see langword="true"/> if this button is the default button in the task dialog;
-        ///   otherwise, <see langword="false"/>. The default value is <see langword="false"/>.
-        /// </value>
-        /// <remarks>
-        /// <para>
-        ///   Only a single button in a task dialog can be set as the default button.
-        /// </para>
-        /// </remarks>
-        public bool DefaultButton
-        {
-            get => _defaultButton;
-
-            set
-            {
-                _defaultButton = value;
-
-                // If we are part of a collection, set the defaultButton value of
-                // all other buttons to false.
-                // Note that this does not handle buttons that are added later to
-                // the collection.
-                if (Collection == null || !value)
-                {
-                    return;
-                }
-
-                foreach (TaskDialogButton button in Collection)
-                {
-                    button._defaultButton = button == this;
-                }
             }
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TaskDialogButtonCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TaskDialogButtonCollection.cs
@@ -33,16 +33,13 @@ namespace System.Windows.Forms
         /// </summary>
         /// <param name="text">The text of the custom button.</param>
         /// <param name="enabled">A value indicating whether the button can respond to user interaction.</param>
-        /// <param name="defaultButton">A value that indicates whether this button is the default button
-        ///   in the task dialog.
-        /// </param>
         /// <param name="allowCloseDialog">A value that indicates whether the task dialog should close
         ///   when this button is clicked.
         /// </param>
         /// <returns>The created <see cref="TaskDialogButton"/>.</returns>
-        public TaskDialogButton Add(string? text, bool enabled = true, bool defaultButton = false, bool allowCloseDialog = true)
+        public TaskDialogButton Add(string? text, bool enabled = true, bool allowCloseDialog = true)
         {
-            var button = new TaskDialogButton(text, enabled, defaultButton, allowCloseDialog);
+            var button = new TaskDialogButton(text, enabled, allowCloseDialog);
             Add(button);
 
             return button;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TaskDialogCommandLinkButton.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TaskDialogCommandLinkButton.cs
@@ -26,9 +26,6 @@ namespace System.Windows.Forms
         /// <param name="descriptionText">An additional description text that will be displayed in
         /// a separate line when the <see cref="TaskDialogButton"/>s of the task dialog are
         /// shown as command links (see <see cref="DescriptionText"/>).</param>
-        /// <param name="defaultButton">A value that indicates whether this button is the default button
-        /// in the task dialog.
-        /// </param>
         /// <param name="allowCloseDialog">A value that indicates whether the task dialog should close
         ///   when this button is clicked.
         /// </param>
@@ -36,9 +33,8 @@ namespace System.Windows.Forms
             string? text,
             string? descriptionText = null,
             bool enabled = true,
-            bool defaultButton = false,
             bool allowCloseDialog = true)
-            : base(text, enabled, defaultButton, allowCloseDialog)
+            : base(text, enabled, allowCloseDialog)
         {
             _descriptionText = descriptionText;
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TaskDialogPage.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TaskDialogPage.cs
@@ -778,7 +778,10 @@ namespace System.Windows.Forms
                     throw new InvalidOperationException(SR.TaskDialogDefaultButtonMustExistInCollection);
                 }
 
-                defaultButtonID = DefaultButton.ButtonID;
+                if (DefaultButton.IsCreated)
+                {
+                    defaultButtonID = DefaultButton.ButtonID;
+                }
             }
             else if (DefaultButton == null && _buttons.Any())
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TaskDialogPage.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TaskDialogPage.cs
@@ -141,6 +141,14 @@ namespace System.Windows.Forms
         }
 
         /// <summary>
+        ///   Gets or sets the default button in the task dialog.
+        /// </summary>
+        /// <value>
+        ///   The default button in the task dialog.
+        /// </value>
+        public TaskDialogButton? DefaultButton { get; set; }
+
+        /// <summary>
         ///   Gets or sets the collection of radio buttons
         ///   to be shown in this page.
         /// </summary>
@@ -660,11 +668,6 @@ namespace System.Windows.Forms
                 throw new InvalidOperationException(SR.TaskDialogTooManyButtonsAdded);
             }
 
-            if (_buttons.Count(e => e.DefaultButton) > 1)
-            {
-                throw new InvalidOperationException(SR.TaskDialogOnlySingleButtonCanBeDefault);
-            }
-
             if (_radioButtons.Count(e => e.Checked) > 1)
             {
                 throw new InvalidOperationException(SR.TaskDialogOnlySingleRadioButtonCanBeChecked);
@@ -758,11 +761,6 @@ namespace System.Windows.Forms
                 if (standardButton.IsCreated)
                 {
                     buttonFlags |= standardButton.GetStandardButtonFlag();
-
-                    if (standardButton.DefaultButton && defaultButtonID == 0)
-                    {
-                        defaultButtonID = standardButton.ButtonID;
-                    }
                 }
             }
 
@@ -770,14 +768,21 @@ namespace System.Windows.Forms
             {
                 TaskDialogButton customButton = _boundCustomButtons[i];
                 flags |= customButton.Bind(this, CustomButtonStartID + i);
+            }
 
-                if (customButton.IsCreated)
+            if (DefaultButton != null)
+            {
+                // ensure the default button is part of the button collection
+                if (!buttons.Contains(DefaultButton))
                 {
-                    if (customButton.DefaultButton && defaultButtonID == 0)
-                    {
-                        defaultButtonID = customButton.ButtonID;
-                    }
+                    throw new InvalidOperationException(SR.TaskDialogDefaultButtonMustExistInCollection);
                 }
+
+                defaultButtonID = DefaultButton.ButtonID;
+            }
+            else if (DefaultButton == null && _buttons.Any())
+            {
+                defaultButtonID = _buttons.First().ButtonID;
             }
 
             defaultRadioButtonID = 0;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TaskDialogPage.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TaskDialogPage.cs
@@ -783,10 +783,6 @@ namespace System.Windows.Forms
                     defaultButtonID = DefaultButton.ButtonID;
                 }
             }
-            else if (DefaultButton == null && _buttons.Any())
-            {
-                defaultButtonID = _buttons.First().ButtonID;
-            }
 
             defaultRadioButtonID = 0;
             for (int i = 0; i < radioButtons.Count; i++)


### PR DESCRIPTION
The original design allowed a user to mark multiple buttons as default.
In this situation there will be a RTE, which is not the best devex/UX.

Shift assignment of the default button to the dialog. This way the API are similar to the MessageBox API, and the user is able to assign only one button.

If the button doesn't belong to the collection of buttons - there will be a RTE.
