### PR TITLE
Simplify setting dialog icon from bitmaps

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.DestroyIcon.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.DestroyIcon.cs
@@ -1,0 +1,15 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class User32
+    {
+        [DllImport(Libraries.User32, ExactSpelling = true, SetLastError = true)]
+        public extern static BOOL DestroyIcon(IntPtr handle);
+    }
+}

--- a/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
@@ -62,7 +62,9 @@ System.Windows.Forms.TaskDialogFooter.TaskDialogFooter(string text) -> void
 System.Windows.Forms.TaskDialogFooter.Text.get -> string
 System.Windows.Forms.TaskDialogFooter.Text.set -> void
 System.Windows.Forms.TaskDialogIcon
+System.Windows.Forms.TaskDialogIcon.Dispose() -> void
 System.Windows.Forms.TaskDialogIcon.IconHandle.get -> System.IntPtr
+System.Windows.Forms.TaskDialogIcon.TaskDialogIcon(System.Drawing.Bitmap image) -> void
 System.Windows.Forms.TaskDialogIcon.TaskDialogIcon(System.Drawing.Icon icon) -> void
 System.Windows.Forms.TaskDialogIcon.TaskDialogIcon(System.IntPtr iconHandle) -> void
 System.Windows.Forms.TaskDialogPage


### PR DESCRIPTION
Typically images are used from Resources, and those are of `Bitmap` type.
The existing API only takes `Icon` that requires additional work from a developer, which wouldn't be straight forward for a significant part of the development community, e.g.:

```cs
new TaskDialogIcon(Icon.FromHandle(Properties.Resources.Network.GetHicon()))
```

Provide an overload that takes a `Bitmpa` and handles the necessary plumbing.
